### PR TITLE
Support for cucumber 1.3

### DIFF
--- a/lib/specjour.rb
+++ b/lib/specjour.rb
@@ -29,7 +29,7 @@ module Specjour
   autoload :Cucumber, 'specjour/cucumber'
   autoload :RSpec, 'specjour/rspec'
 
-  VERSION ||= "0.7.0.3"
+  VERSION ||= "0.7.0.4"
   HOOKS_PATH ||= "./.specjour/hooks.rb"
   PROGRAM_NAME ||= $PROGRAM_NAME # keep a reference of the original program name
 

--- a/lib/specjour/cucumber/distributed_formatter.rb
+++ b/lib/specjour/cucumber/distributed_formatter.rb
@@ -1,8 +1,8 @@
 module Specjour::Cucumber
   class DistributedFormatter < ::Cucumber::Formatter::Progress
 
-    def initialize(step_mother, io, options)
-      @step_mother = step_mother
+    def initialize(runtime, io, options)
+      @runtime = runtime
       @io = io
       @options = options
       @failing_scenarios = []
@@ -11,12 +11,12 @@ module Specjour::Cucumber
 
     def after_features(features)
       print_summary
-      step_mother.scenarios.clear
-      step_mother.steps.clear
+      @runtime.scenarios.clear
+      @runtime.steps.clear
     end
 
     def prepare_failures
-      step_mother.scenarios(:failed).select do |s|
+      @runtime.scenarios(:failed).select do |s|
         s.is_a?(Cucumber::Ast::Scenario) || s.is_a?(Cucumber::Ast::OutlineTable::ExampleRow)
       end.map do |failure|
         if failure.is_a?(Cucumber::Ast::Scenario)
@@ -49,7 +49,7 @@ module Specjour::Cucumber
     end
 
     def prepare_steps(type)
-      prepare_elements(step_mother.steps(type), type, 'steps')
+      prepare_elements(@runtime.steps(type), type, 'steps')
     end
 
     def print_exception(e, status, indent)
@@ -61,7 +61,7 @@ module Specjour::Cucumber
       prepare_steps(:failed)
       prepare_steps(:undefined)
 
-      @io.send_message(:cucumber_summary=, [step_mother.scenarios[0].file_colon_line, to_hash])
+      @io.send_message(:cucumber_summary=, [@runtime.scenarios[0].file_colon_line, to_hash])
     end
 
     OUTCOMES = [:failed, :skipped, :undefined, :pending, :passed]
@@ -71,7 +71,7 @@ module Specjour::Cucumber
       [:scenarios, :steps].each do |type|
         hash[type] = {}
         OUTCOMES.each do |outcome|
-          hash[type][outcome] = step_mother.send(type, outcome).size
+          hash[type][outcome] = @runtime.send(type, outcome).size
         end
       end
       hash.merge!(:failing_scenarios => @failing_scenarios, :step_summary => @step_summary)

--- a/lib/specjour/cucumber/preloader.rb
+++ b/lib/specjour/cucumber/preloader.rb
@@ -5,11 +5,11 @@ module Specjour
         Specjour.benchmark("Loading Cucumber Environment") do
           require 'cucumber' unless defined?(::Cucumber::Cli)
           args = paths.unshift '--format', 'Specjour::Cucumber::DistributedFormatter'
-          cli = ::Cucumber::Cli::Main.new(args, output)
+          cli = ::Cucumber::Cli::Main.new(args, nil, output)
 
           configuration = cli.configuration
           options = configuration.instance_variable_get(:@options)
-          options.instance_variable_set(:@skip_profile_information, true)
+          options[:skip_profile_information] = true
 
           runtime = ::Cucumber::Runtime.new(configuration)
           runtime.send :load_step_definitions

--- a/lib/specjour/loader.rb
+++ b/lib/specjour/loader.rb
@@ -129,7 +129,8 @@ module Specjour
     def scenarios
       Cucumber.runtime.send(:features).map do |feature|
         feature.feature_elements.map do |scenario|
-          "#{feature.file}:#{scenario.instance_variable_get(:@line)}"
+          location = scenario.location
+          "#{location.file}:#{location.line}"
         end
       end.flatten
     end


### PR DESCRIPTION
Changes required for cucumber 1.3. Current version (1.2.1) of cucumber will not be supported.
Specjour version was updated to ensure a smooth transition in our clients.

I'm available to explain any of the changes introduced.