### PR TITLE
Add support for rails 4

### DIFF
--- a/lib/specjour.rb
+++ b/lib/specjour.rb
@@ -29,7 +29,7 @@ module Specjour
   autoload :Cucumber, 'specjour/cucumber'
   autoload :RSpec, 'specjour/rspec'
 
-  VERSION ||= "0.7.0.4"
+  VERSION ||= "0.7.0.5"
   HOOKS_PATH ||= "./.specjour/hooks.rb"
   PROGRAM_NAME ||= $PROGRAM_NAME # keep a reference of the original program name
 

--- a/lib/specjour/db_scrub.rb
+++ b/lib/specjour/db_scrub.rb
@@ -31,6 +31,13 @@ module Specjour
     def connect_to_database
       ActiveRecord::Base.remove_connection
       ActiveRecord::Base.configurations = Rails.application.config.database_configuration
+
+      # support for rails 4
+      if defined?(ActiveRecord::Tasks::DatabaseTasks)
+        ActiveRecord::Tasks::DatabaseTasks.db_dir = Rails.application.config.paths["db"].first
+        ActiveRecord::Tasks::DatabaseTasks.database_configuration = Rails.application.config.database_configuration
+      end
+
       ActiveRecord::Base.establish_connection
       connection
     rescue # assume the database doesn't exist


### PR DESCRIPTION
The problem with rails 4 seems to be related with (the new) `ActiveRecord::Tasks::DatabaseTasks` used in tasks.

Not sure if this is the best fix, but seems to be working.